### PR TITLE
Add extra payment properties

### DIFF
--- a/src/main/java/nl/stil4m/mollie/domain/CreatePayment.java
+++ b/src/main/java/nl/stil4m/mollie/domain/CreatePayment.java
@@ -1,6 +1,9 @@
 package nl.stil4m.mollie.domain;
 
+import java.util.HashMap;
 import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
 
 public class CreatePayment {
 
@@ -9,6 +12,7 @@ public class CreatePayment {
     private final String redirectUrl;
     private final String method;
     private final Map<String, Object> metadata;
+    private final Map<String, Object> extraProperties;
 
     public CreatePayment(String method, Double amount, String description, String redirectUrl, Map<String, Object> metadata) {
         this.method = method;
@@ -16,6 +20,7 @@ public class CreatePayment {
         this.description = description;
         this.redirectUrl = redirectUrl;
         this.metadata = metadata;
+        this.extraProperties = new HashMap<>();
     }
 
     public Double getAmount() {
@@ -36,5 +41,15 @@ public class CreatePayment {
 
     public Map<String, Object> getMetadata() {
         return metadata;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getExtraProperties() {
+        return extraProperties;
+    }
+
+    public CreatePayment setProperty(String name, Object value) {
+        extraProperties.put(name, value);
+        return this;
     }
 }

--- a/src/test/java/nl/stil4m/mollie/domain/subpayments/CreateIdealPaymentTest.java
+++ b/src/test/java/nl/stil4m/mollie/domain/subpayments/CreateIdealPaymentTest.java
@@ -1,6 +1,8 @@
 package nl.stil4m.mollie.domain.subpayments;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+
+import nl.stil4m.mollie.domain.CreatePayment;
 import nl.stil4m.mollie.domain.subpayments.ideal.CreateIdealPayment;
 import nl.stil4m.mollie.domain.subpayments.ideal.IdealPaymentOptions;
 import org.junit.Test;
@@ -20,7 +22,9 @@ public class CreateIdealPaymentTest {
         ObjectMapper objectMapper = new ObjectMapper();
         Map<String, Object> metaData = new HashMap<>();
         metaData.put("mySpecialKey", "value");
-        String serialized = objectMapper.writeValueAsString(new CreateIdealPayment(1.0, "Description", "redirectUrl", metaData, new IdealPaymentOptions("MyIssuer")));
+        CreatePayment payment = new CreateIdealPayment(1.0, "Description", "redirectUrl", metaData, new IdealPaymentOptions("MyIssuer"))
+                .setProperty("webhookUrl", "webhookUrl");
+        String serialized = objectMapper.writeValueAsString(payment);
 
         Map mapRepresentation = objectMapper.readValue(serialized, Map.class);
         InputStream resourceAsStream = this.getClass().getResourceAsStream("/expected_create_ideal_payment.json");

--- a/src/test/resources/expected_create_ideal_payment.json
+++ b/src/test/resources/expected_create_ideal_payment.json
@@ -2,6 +2,7 @@
   "amount": 1.0,
   "description": "Description",
   "redirectUrl": "redirectUrl",
+  "webhookUrl": "webhookUrl",
   "method": "ideal",
   "metadata": {
     "mySpecialKey": "value"


### PR DESCRIPTION
This is an implementation for #15 that adds a method for adding extra parameters to `CreatePayment` instances. This violates the immutability of `CreatePayment` (at least in spirit) but touches much less code than #16 and works for any extra parameters.
