### PR TITLE
tests using hamcrest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,12 +49,6 @@
             <version>1.3</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>19.0</version>
-            <scope>test</scope>
-        </dependency>
 
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>

--- a/src/test/java/nl/stil4m/mollie/concepts/IssuersIntegrationTest.java
+++ b/src/test/java/nl/stil4m/mollie/concepts/IssuersIntegrationTest.java
@@ -3,6 +3,7 @@ package nl.stil4m.mollie.concepts;
 import static nl.stil4m.mollie.TestUtil.TEST_TIMEOUT;
 import static nl.stil4m.mollie.TestUtil.VALID_API_KEY;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 
@@ -14,8 +15,6 @@ import java.util.stream.Collectors;
 
 import org.junit.Before;
 import org.junit.Test;
-
-import com.google.common.collect.Sets;
 
 import nl.stil4m.mollie.ClientBuilder;
 import nl.stil4m.mollie.ResponseOrError;
@@ -47,7 +46,7 @@ public class IssuersIntegrationTest {
         assertThat(all.getLinks().getNext().isPresent(), is(false));
 
         Set<String> identifiers = all.getData().stream().map(Issuer::getId).collect(Collectors.toSet());
-        assertThat(identifiers.containsAll(Sets.newHashSet("ideal_TESTNL99")), is(true));
+        assertThat(identifiers,hasItems("ideal_TESTNL99"));
     }
 
     @Test

--- a/src/test/java/nl/stil4m/mollie/concepts/MethodsIntegrationTest.java
+++ b/src/test/java/nl/stil4m/mollie/concepts/MethodsIntegrationTest.java
@@ -5,17 +5,18 @@ import static nl.stil4m.mollie.TestUtil.VALID_API_KEY;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.hasKey;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.junit.Before;
 import org.junit.Test;
-
-import com.google.common.collect.Sets;
 
 import nl.stil4m.mollie.ClientBuilder;
 import nl.stil4m.mollie.ResponseOrError;
@@ -44,7 +45,7 @@ public class MethodsIntegrationTest {
         assertThat(all.getLinks(), is(notNullValue()));
 
         Set<String> identifiers = all.getData().stream().map(Method::getId).collect(Collectors.toSet());
-        assertThat(identifiers.containsAll(Sets.newHashSet("ideal", "creditcard", "paypal")), is(true));
+        assertThat(identifiers,hasItems("ideal", "creditcard", "paypal"));
     }
 
     @Test
@@ -68,6 +69,6 @@ public class MethodsIntegrationTest {
         
         assertThat(methodResponse.getSuccess(), is(false));
         assertThat(methodResponse.getStatus(), is(404));
-        assertThat(methodResponse.getError().keySet(), is(Sets.newHashSet("error")));
+        assertThat((Map<String,?>)methodResponse.getError(), hasKey("error"));
     }
 }


### PR DESCRIPTION
replacing the need of Guava as test dependency

this pull-request is not a must have, but imo it's always a good thing to reduce dependencies (smaller footprint), it just leverages more hamcrest in favor of Guava

perhaps it's part of #18 
