### PR TITLE
minor test cleanup

### DIFF
--- a/src/test/java/nl/stil4m/mollie/IssuesIntegrationTest.java
+++ b/src/test/java/nl/stil4m/mollie/IssuesIntegrationTest.java
@@ -7,10 +7,11 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.Optional;
 
-import static java.util.Collections.EMPTY_MAP;
 import static nl.stil4m.mollie.TestUtil.TEST_TIMEOUT;
+import static nl.stil4m.mollie.TestUtil.VALID_API_KEY;
 import static nl.stil4m.mollie.TestUtil.strictClientWithApiKey;
 
 public class IssuesIntegrationTest {
@@ -21,15 +22,14 @@ public class IssuesIntegrationTest {
     @Before
     public void before() throws InterruptedException {
         Thread.sleep(TEST_TIMEOUT);
-        client = strictClientWithApiKey(TestUtil.VALID_API_KEY);
+        client = strictClientWithApiKey(VALID_API_KEY);
     }
 
     //Issue #13
     @Test
     public void validateInvalidApiKey() throws IOException {
-        CreatePayment createPayment = new CreateIdealPayment(36.0, "Test", "http://example.com", Optional.empty(), EMPTY_MAP, new IdealPaymentOptions("ideal_TESTNL99"));
+        CreatePayment createPayment = new CreateIdealPayment(36.0, "Test", "http://example.com", Optional.empty(), Collections.emptyMap(), new IdealPaymentOptions("ideal_TESTNL99"));
         client.payments().create(createPayment);
         //Should not give a deserialization error.
     }
-
 }

--- a/src/test/java/nl/stil4m/mollie/TestUtil.java
+++ b/src/test/java/nl/stil4m/mollie/TestUtil.java
@@ -25,9 +25,9 @@ public class TestUtil {
         assertThat(target, lessThanOrEqualTo(new Date(afterTime)));
     }
 
-    public static ObjectMapper objectMapper(boolean strict) {
+    public static ObjectMapper objectMapper() {
         ObjectMapper objectMapper = new ObjectMapper();
-        objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, strict);
+        objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, true);
         objectMapper.registerModule(new Jdk8Module());
         return objectMapper;
     }
@@ -35,13 +35,13 @@ public class TestUtil {
     public static Client strictClientWithApiKey(String apiKey) {
         return new ClientBuilder()
                 .withApiKey(apiKey)
-                .withMapper(objectMapper(true))
+                .withMapper(objectMapper())
                 .build();
     }
 
     public static DynamicClient strictDynamicClientWithApiKey() {
         return new DynamicClientBuilder()
-                .withMapper(objectMapper(true))
+                .withMapper(objectMapper())
                 .build();
     }
 }

--- a/src/test/java/nl/stil4m/mollie/concepts/IssuersIntegrationTest.java
+++ b/src/test/java/nl/stil4m/mollie/concepts/IssuersIntegrationTest.java
@@ -1,6 +1,5 @@
 package nl.stil4m.mollie.concepts;
 
-import nl.stil4m.mollie.ClientBuilder;
 import nl.stil4m.mollie.ResponseOrError;
 import nl.stil4m.mollie.domain.Issuer;
 import nl.stil4m.mollie.domain.Page;
@@ -16,6 +15,7 @@ import java.util.stream.Collectors;
 import static nl.stil4m.mollie.TestUtil.TEST_ISSUER;
 import static nl.stil4m.mollie.TestUtil.TEST_TIMEOUT;
 import static nl.stil4m.mollie.TestUtil.VALID_API_KEY;
+import static nl.stil4m.mollie.TestUtil.strictClientWithApiKey;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.is;
@@ -28,7 +28,7 @@ public class IssuersIntegrationTest {
     @Before
     public void before() throws InterruptedException {
         Thread.sleep(TEST_TIMEOUT);
-        issuers = new ClientBuilder().withApiKey(VALID_API_KEY).build().issuers();
+        issuers = strictClientWithApiKey(VALID_API_KEY).issuers();
     }
 
     @Test

--- a/src/test/java/nl/stil4m/mollie/concepts/MethodsIntegrationTest.java
+++ b/src/test/java/nl/stil4m/mollie/concepts/MethodsIntegrationTest.java
@@ -1,6 +1,5 @@
 package nl.stil4m.mollie.concepts;
 
-import nl.stil4m.mollie.ClientBuilder;
 import nl.stil4m.mollie.ResponseOrError;
 import nl.stil4m.mollie.domain.Method;
 import nl.stil4m.mollie.domain.Page;
@@ -16,6 +15,7 @@ import java.util.stream.Collectors;
 
 import static nl.stil4m.mollie.TestUtil.TEST_TIMEOUT;
 import static nl.stil4m.mollie.TestUtil.VALID_API_KEY;
+import static nl.stil4m.mollie.TestUtil.strictClientWithApiKey;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.hasKey;
@@ -29,7 +29,7 @@ public class MethodsIntegrationTest {
     @Before
     public void before() throws InterruptedException {
         Thread.sleep(TEST_TIMEOUT);
-        methods = new ClientBuilder().withApiKey(VALID_API_KEY).build().methods();
+        methods = strictClientWithApiKey(VALID_API_KEY).methods();
     }
 
     @Test

--- a/src/test/java/nl/stil4m/mollie/concepts/PaymentsIntegrationTest.java
+++ b/src/test/java/nl/stil4m/mollie/concepts/PaymentsIntegrationTest.java
@@ -1,7 +1,6 @@
 package nl.stil4m.mollie.concepts;
 
 import nl.stil4m.mollie.Client;
-import nl.stil4m.mollie.ClientBuilder;
 import nl.stil4m.mollie.ResponseOrError;
 import nl.stil4m.mollie.domain.CreatePayment;
 import nl.stil4m.mollie.domain.Issuer;
@@ -22,6 +21,7 @@ import java.util.Optional;
 import static nl.stil4m.mollie.TestUtil.TEST_TIMEOUT;
 import static nl.stil4m.mollie.TestUtil.VALID_API_KEY;
 import static nl.stil4m.mollie.TestUtil.assertWithin;
+import static nl.stil4m.mollie.TestUtil.strictClientWithApiKey;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
@@ -36,7 +36,7 @@ public class PaymentsIntegrationTest {
     @Before
     public void before() throws InterruptedException {
         Thread.sleep(TEST_TIMEOUT);
-        Client client = new ClientBuilder().withApiKey(VALID_API_KEY).build();
+        Client client = strictClientWithApiKey(VALID_API_KEY);
         payments = client.payments();
         issuers = client.issuers();
     }

--- a/src/test/java/nl/stil4m/mollie/concepts/RefundsIntegrationTest.java
+++ b/src/test/java/nl/stil4m/mollie/concepts/RefundsIntegrationTest.java
@@ -1,7 +1,6 @@
 package nl.stil4m.mollie.concepts;
 
 import nl.stil4m.mollie.Client;
-import nl.stil4m.mollie.ClientBuilder;
 import nl.stil4m.mollie.ResponseOrError;
 import nl.stil4m.mollie.domain.CreatePayment;
 import nl.stil4m.mollie.domain.Page;
@@ -18,6 +17,7 @@ import java.util.Optional;
 
 import static nl.stil4m.mollie.TestUtil.TEST_TIMEOUT;
 import static nl.stil4m.mollie.TestUtil.VALID_API_KEY;
+import static nl.stil4m.mollie.TestUtil.strictClientWithApiKey;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
@@ -30,7 +30,7 @@ public class RefundsIntegrationTest {
     @Before
     public void before() throws InterruptedException {
         Thread.sleep(TEST_TIMEOUT);
-        Client client = new ClientBuilder().withApiKey(VALID_API_KEY).build();
+        Client client = strictClientWithApiKey(VALID_API_KEY);
         refunds = client.refunds();
         payments = client.payments();
     }

--- a/src/test/java/nl/stil4m/mollie/domain/PaymentSerializationTest.java
+++ b/src/test/java/nl/stil4m/mollie/domain/PaymentSerializationTest.java
@@ -20,7 +20,7 @@ public class PaymentSerializationTest {
 
     @Test
     public void testSerializeFirstRecurringPayment() throws IOException {
-        ObjectMapper mapper = objectMapper(true);
+        ObjectMapper mapper = objectMapper();
         Map<String, Object> metaData = new HashMap<>();
 
         CustomerPayment customerPayment = new FirstRecurringPayment(new CreateIdealPayment(1.0, "Description", "redirectUrl", Optional.empty(), metaData, new IdealPaymentOptions("MyIssuer")));
@@ -34,8 +34,7 @@ public class PaymentSerializationTest {
 
     @Test
     public void testDeserializeRecurringPaymentResponse() throws IOException {
-        // FIXME #32 response on recurring payments contains more info; test fails if strict is true
-        ObjectMapper mapper = objectMapper(true);
+        ObjectMapper mapper = objectMapper();
         InputStream resourceAsStream = getClass().getResourceAsStream("/response_create_recurring_payment.json");
 
         Payment payment = mapper.readValue(resourceAsStream, Payment.class);


### PR DESCRIPTION
now #38 is fixed the non-strict ObjectMapper wasn't needed anymore in testing

also using TestUtil.strictClientWithApiKey more consistently