### PR TITLE
Added Client.customerSubscriptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ target
 .settings
 .idea
 *.iml
+nb-configuration.xml

--- a/nb-configuration.xml
+++ b/nb-configuration.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project-shared-configuration>
+    <!--
+This file contains additional configuration written by modules in the NetBeans IDE.
+The configuration is intended to be shared among all the users of project and
+therefore it is assumed to be part of version control checkout.
+Without this configuration present, some functionality in the IDE may be limited or fail altogether.
+-->
+    <properties xmlns="http://www.netbeans.org/ns/maven-properties-data/1">
+        <!--
+Properties that influence various parts of the IDE, especially code formatting and the like. 
+You can copy and paste the single properties, into the pom.xml file and the IDE will pick them up.
+That way multiple projects can share the same settings (useful for formatting rules for example).
+Any value defined here will override the pom.xml file value but is only applicable to the current project.
+-->
+        <org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.importGroupsOrder>*</org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.importGroupsOrder>
+        <org-netbeans-modules-editor-indent.CodeStyle.project.text-line-wrap>none</org-netbeans-modules-editor-indent.CodeStyle.project.text-line-wrap>
+        <org-netbeans-modules-editor-indent.CodeStyle.project.indent-shift-width>4</org-netbeans-modules-editor-indent.CodeStyle.project.indent-shift-width>
+        <org-netbeans-modules-editor-indent.CodeStyle.project.spaces-per-tab>4</org-netbeans-modules-editor-indent.CodeStyle.project.spaces-per-tab>
+        <org-netbeans-modules-editor-indent.CodeStyle.project.tab-size>8</org-netbeans-modules-editor-indent.CodeStyle.project.tab-size>
+        <org-netbeans-modules-editor-indent.CodeStyle.project.text-limit-width>150</org-netbeans-modules-editor-indent.CodeStyle.project.text-limit-width>
+        <org-netbeans-modules-editor-indent.CodeStyle.project.expand-tabs>true</org-netbeans-modules-editor-indent.CodeStyle.project.expand-tabs>
+        <org-netbeans-modules-editor-indent.CodeStyle.usedProfile>project</org-netbeans-modules-editor-indent.CodeStyle.usedProfile>
+        <org-netbeans-modules-javascript2-requirejs.enabled>true</org-netbeans-modules-javascript2-requirejs.enabled>
+    </properties>
+</project-shared-configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,12 @@
             <version>3.11.0</version>
             <scope>test</scope>
         </dependency>
-
+        <dependency>
+            <groupId>io.github.bonigarcia</groupId>
+            <artifactId>webdrivermanager</artifactId>
+            <version>1.4.9</version>
+            <scope>test</scope>
+        </dependency>
 
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,31 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.2</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jdk8</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <version>3.0.0</version>
+        </dependency>
 
         <!-- Testing -->
         <dependency>
@@ -58,35 +83,8 @@
         <dependency>
             <groupId>io.github.bonigarcia</groupId>
             <artifactId>webdrivermanager</artifactId>
-            <version>1.4.9</version>
+            <version>2.2.1</version>
             <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-            <version>4.5.2</version>
-        </dependency>
-
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-annotations</artifactId>
-            <version>${jackson.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-            <version>${jackson.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.datatype</groupId>
-            <artifactId>jackson-datatype-jdk8</artifactId>
-            <version>${jackson.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>jsr305</artifactId>
-            <version>3.0.0</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,13 @@
             <version>1.3</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.seleniumhq.selenium</groupId>
+            <artifactId>selenium-java</artifactId>
+            <version>3.11.0</version>
+            <scope>test</scope>
+        </dependency>
+
 
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>

--- a/src/main/java/nl/stil4m/mollie/Client.java
+++ b/src/main/java/nl/stil4m/mollie/Client.java
@@ -1,6 +1,15 @@
 package nl.stil4m.mollie;
 
-import nl.stil4m.mollie.concepts.*;
+import nl.stil4m.mollie.concepts.CustomerMandates;
+import nl.stil4m.mollie.concepts.CustomerPayments;
+import nl.stil4m.mollie.concepts.CustomerSubscriptions;
+import nl.stil4m.mollie.concepts.Customers;
+import nl.stil4m.mollie.concepts.Issuers;
+import nl.stil4m.mollie.concepts.Methods;
+import nl.stil4m.mollie.concepts.PaymentRefunds;
+import nl.stil4m.mollie.concepts.Payments;
+import nl.stil4m.mollie.concepts.Refunds;
+import nl.stil4m.mollie.concepts.Status;
 
 public class Client {
 
@@ -27,9 +36,9 @@ public class Client {
     public Issuers issuers() {
         return dynamicClient.issuers(apiKey);
     }
-    
+
     public Refunds refunds() {
-    	return dynamicClient.refunds(apiKey);
+        return dynamicClient.refunds(apiKey);
     }
 
     public PaymentRefunds paymentRefunds(String paymentId) {

--- a/src/main/java/nl/stil4m/mollie/Client.java
+++ b/src/main/java/nl/stil4m/mollie/Client.java
@@ -1,11 +1,13 @@
 package nl.stil4m.mollie;
 
+import nl.stil4m.mollie.concepts.Chargebacks;
 import nl.stil4m.mollie.concepts.CustomerMandates;
 import nl.stil4m.mollie.concepts.CustomerPayments;
 import nl.stil4m.mollie.concepts.CustomerSubscriptions;
 import nl.stil4m.mollie.concepts.Customers;
 import nl.stil4m.mollie.concepts.Issuers;
 import nl.stil4m.mollie.concepts.Methods;
+import nl.stil4m.mollie.concepts.PaymentChargebacks;
 import nl.stil4m.mollie.concepts.PaymentRefunds;
 import nl.stil4m.mollie.concepts.Payments;
 import nl.stil4m.mollie.concepts.Refunds;
@@ -59,5 +61,13 @@ public class Client {
 
     public CustomerSubscriptions customerSubscriptions(String customerId) {
         return dynamicClient.customerSubscriptions(apiKey, customerId);
+    }
+
+    public PaymentChargebacks paymentChargebacks(String paymentId) {
+        return dynamicClient.paymentChargebacks(apiKey, paymentId);
+    }
+
+    public Chargebacks chargebacks() {
+        return dynamicClient.chargebacks(apiKey);
     }
 }

--- a/src/main/java/nl/stil4m/mollie/Client.java
+++ b/src/main/java/nl/stil4m/mollie/Client.java
@@ -1,20 +1,11 @@
 package nl.stil4m.mollie;
 
-import nl.stil4m.mollie.concepts.CustomerPayments;
-import nl.stil4m.mollie.concepts.Customers;
-import nl.stil4m.mollie.concepts.Issuers;
-import nl.stil4m.mollie.concepts.CustomerMandates;
-import nl.stil4m.mollie.concepts.Methods;
-import nl.stil4m.mollie.concepts.Payments;
-import nl.stil4m.mollie.concepts.Refunds;
-import nl.stil4m.mollie.concepts.PaymentRefunds;
-import nl.stil4m.mollie.concepts.Status;
+import nl.stil4m.mollie.concepts.*;
 
 public class Client {
 
     private final DynamicClient dynamicClient;
     private final String apiKey;
-
 
     public Client(DynamicClient dynamicClient, String apiKey) {
         this.dynamicClient = dynamicClient;
@@ -55,5 +46,9 @@ public class Client {
 
     public CustomerMandates customerMandates(String customerId) {
         return dynamicClient.customerMandates(apiKey, customerId);
+    }
+
+    public CustomerSubscriptions customerSubscriptions(String customerId) {
+        return dynamicClient.customerSubscriptions(apiKey, customerId);
     }
 }

--- a/src/main/java/nl/stil4m/mollie/DynamicClient.java
+++ b/src/main/java/nl/stil4m/mollie/DynamicClient.java
@@ -1,14 +1,6 @@
 package nl.stil4m.mollie;
 
-import nl.stil4m.mollie.concepts.CustomerPayments;
-import nl.stil4m.mollie.concepts.Customers;
-import nl.stil4m.mollie.concepts.Issuers;
-import nl.stil4m.mollie.concepts.CustomerMandates;
-import nl.stil4m.mollie.concepts.Methods;
-import nl.stil4m.mollie.concepts.Payments;
-import nl.stil4m.mollie.concepts.Refunds;
-import nl.stil4m.mollie.concepts.PaymentRefunds;
-import nl.stil4m.mollie.concepts.Status;
+import nl.stil4m.mollie.concepts.*;
 
 public class DynamicClient {
 
@@ -35,7 +27,7 @@ public class DynamicClient {
     public Issuers issuers(String apiKey) {
         return new Issuers(apiKey, endpoint, requestExecutor);
     }
-    
+
     public Refunds refunds(String apiKey) {
         return new Refunds(apiKey, endpoint, requestExecutor);
     }
@@ -54,5 +46,9 @@ public class DynamicClient {
 
     public CustomerMandates customerMandates(String apiKey, String customerId) {
         return new CustomerMandates(apiKey, endpoint, requestExecutor, customerId);
+    }
+
+    public CustomerSubscriptions customerSubscriptions(String apiKey, String customerId) {
+        return new CustomerSubscriptions(apiKey, endpoint, requestExecutor, customerId);
     }
 }

--- a/src/main/java/nl/stil4m/mollie/DynamicClient.java
+++ b/src/main/java/nl/stil4m/mollie/DynamicClient.java
@@ -51,4 +51,12 @@ public class DynamicClient {
     public CustomerSubscriptions customerSubscriptions(String apiKey, String customerId) {
         return new CustomerSubscriptions(apiKey, endpoint, requestExecutor, customerId);
     }
+
+    public PaymentChargebacks paymentChargebacks(String apiKey, String paymentId) {
+        return new PaymentChargebacks(apiKey, endpoint, requestExecutor, paymentId);
+    }
+
+    public Chargebacks chargebacks(String apiKey) {
+        return new Chargebacks(apiKey, endpoint, requestExecutor);
+    }
 }

--- a/src/main/java/nl/stil4m/mollie/DynamicClient.java
+++ b/src/main/java/nl/stil4m/mollie/DynamicClient.java
@@ -1,6 +1,17 @@
 package nl.stil4m.mollie;
 
-import nl.stil4m.mollie.concepts.*;
+import nl.stil4m.mollie.concepts.Chargebacks;
+import nl.stil4m.mollie.concepts.CustomerMandates;
+import nl.stil4m.mollie.concepts.CustomerPayments;
+import nl.stil4m.mollie.concepts.CustomerSubscriptions;
+import nl.stil4m.mollie.concepts.Customers;
+import nl.stil4m.mollie.concepts.Issuers;
+import nl.stil4m.mollie.concepts.Methods;
+import nl.stil4m.mollie.concepts.PaymentChargebacks;
+import nl.stil4m.mollie.concepts.PaymentRefunds;
+import nl.stil4m.mollie.concepts.Payments;
+import nl.stil4m.mollie.concepts.Refunds;
+import nl.stil4m.mollie.concepts.Status;
 
 public class DynamicClient {
 

--- a/src/main/java/nl/stil4m/mollie/concepts/Chargebacks.java
+++ b/src/main/java/nl/stil4m/mollie/concepts/Chargebacks.java
@@ -1,0 +1,22 @@
+package nl.stil4m.mollie.concepts;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import nl.stil4m.mollie.RequestExecutor;
+import nl.stil4m.mollie.domain.Chargeback;
+import nl.stil4m.mollie.domain.Page;
+
+/**
+ *
+ * @author stevensnoeijen
+ */
+public class Chargebacks extends AbstractConcept<Chargeback> implements ListAll<Chargeback> {
+
+    private static final TypeReference<Page<Chargeback>> PAGE_TYPE = new TypeReference<Page<Chargeback>>() {
+    };
+    private static final TypeReference<Chargeback> SINGLE_TYPE = new TypeReference<Chargeback>() {
+    };
+
+    public Chargebacks(String apiKey, String endPoint, RequestExecutor requestExecutor) {
+        super(apiKey, requestExecutor, SINGLE_TYPE, PAGE_TYPE, endPoint, "chargebacks");
+    }
+}

--- a/src/main/java/nl/stil4m/mollie/concepts/Chargebacks.java
+++ b/src/main/java/nl/stil4m/mollie/concepts/Chargebacks.java
@@ -5,10 +5,6 @@ import nl.stil4m.mollie.RequestExecutor;
 import nl.stil4m.mollie.domain.Chargeback;
 import nl.stil4m.mollie.domain.Page;
 
-/**
- *
- * @author stevensnoeijen
- */
 public class Chargebacks extends AbstractConcept<Chargeback> implements ListAll<Chargeback> {
 
     private static final TypeReference<Page<Chargeback>> PAGE_TYPE = new TypeReference<Page<Chargeback>>() {

--- a/src/main/java/nl/stil4m/mollie/concepts/CustomerPayments.java
+++ b/src/main/java/nl/stil4m/mollie/concepts/CustomerPayments.java
@@ -4,7 +4,7 @@ import nl.stil4m.mollie.RequestExecutor;
 import nl.stil4m.mollie.domain.CustomerPayment;
 import nl.stil4m.mollie.domain.Payment;
 
-public class CustomerPayments extends AbstractConcept<Payment> implements ListAll<Payment>, Create<Payment, CustomerPayment> {
+public class CustomerPayments extends AbstractConcept<Payment> implements ListAll<Payment>, Create<Payment, CustomerPayment>, GetById<Payment> {
 
     public CustomerPayments(String apiKey, String endpoint, RequestExecutor requestExecutor, String customerId) {
         super(apiKey, requestExecutor, Payments.SINGLE_TYPE, Payments.PAGE_TYPE, endpoint, "customers", customerId, "payments");

--- a/src/main/java/nl/stil4m/mollie/concepts/CustomerSubscriptions.java
+++ b/src/main/java/nl/stil4m/mollie/concepts/CustomerSubscriptions.java
@@ -1,0 +1,19 @@
+package nl.stil4m.mollie.concepts;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import nl.stil4m.mollie.RequestExecutor;
+import nl.stil4m.mollie.domain.CreateSubscription;
+import nl.stil4m.mollie.domain.Page;
+import nl.stil4m.mollie.domain.Subscription;
+
+public class CustomerSubscriptions extends AbstractConcept<Subscription> implements ListAll<Subscription>, GetById<Subscription>, Create<Subscription, CreateSubscription>, DeleteWithResponse<Subscription> {
+
+    private static final TypeReference<Page<Subscription>> PAGE_TYPE = new TypeReference<Page<Subscription>>() {
+    };
+    private static final TypeReference<Subscription> SINGLE_TYPE = new TypeReference<Subscription>() {
+    };
+
+    public CustomerSubscriptions(String apiKey, String endpoint, RequestExecutor requestExecutor, String customerId) {
+        super(apiKey, requestExecutor, SINGLE_TYPE, PAGE_TYPE, endpoint, "customers", customerId, "subscriptions");
+    }
+}

--- a/src/main/java/nl/stil4m/mollie/concepts/DeleteWithResponse.java
+++ b/src/main/java/nl/stil4m/mollie/concepts/DeleteWithResponse.java
@@ -1,0 +1,17 @@
+package nl.stil4m.mollie.concepts;
+
+import java.io.IOException;
+import nl.stil4m.mollie.ResponseOrError;
+import org.apache.http.client.methods.HttpDelete;
+
+/**
+ *
+ * @author stevensnoeijen
+ */
+public interface DeleteWithResponse<T> extends Concept<T> {
+
+    default ResponseOrError<T> delete(String id) throws IOException {
+        HttpDelete httpDelete = new HttpDelete(url(id));
+        return requestSingle(httpDelete);
+    }
+}

--- a/src/main/java/nl/stil4m/mollie/concepts/DeleteWithResponse.java
+++ b/src/main/java/nl/stil4m/mollie/concepts/DeleteWithResponse.java
@@ -1,8 +1,9 @@
 package nl.stil4m.mollie.concepts;
 
-import java.io.IOException;
 import nl.stil4m.mollie.ResponseOrError;
 import org.apache.http.client.methods.HttpDelete;
+
+import java.io.IOException;
 
 public interface DeleteWithResponse<T> extends Concept<T> {
 

--- a/src/main/java/nl/stil4m/mollie/concepts/DeleteWithResponse.java
+++ b/src/main/java/nl/stil4m/mollie/concepts/DeleteWithResponse.java
@@ -4,10 +4,6 @@ import java.io.IOException;
 import nl.stil4m.mollie.ResponseOrError;
 import org.apache.http.client.methods.HttpDelete;
 
-/**
- *
- * @author stevensnoeijen
- */
 public interface DeleteWithResponse<T> extends Concept<T> {
 
     default ResponseOrError<T> delete(String id) throws IOException {

--- a/src/main/java/nl/stil4m/mollie/concepts/PaymentChargebacks.java
+++ b/src/main/java/nl/stil4m/mollie/concepts/PaymentChargebacks.java
@@ -1,0 +1,21 @@
+package nl.stil4m.mollie.concepts;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import nl.stil4m.mollie.RequestExecutor;
+import nl.stil4m.mollie.domain.Chargeback;
+import nl.stil4m.mollie.domain.Page;
+
+/**
+ *
+ */
+public class PaymentChargebacks extends AbstractConcept<Chargeback> implements ListAll<Chargeback>, GetById<Chargeback> {
+
+    private static final TypeReference<Page<Chargeback>> PAGE_TYPE = new TypeReference<Page<Chargeback>>() {
+    };
+    private static final TypeReference<Chargeback> SINGLE_TYPE = new TypeReference<Chargeback>() {
+    };
+
+    public PaymentChargebacks(String apiKey, String endpoint, RequestExecutor requestExecutor, String paymentId) {
+        super(apiKey, requestExecutor, SINGLE_TYPE, PAGE_TYPE, endpoint, "payments", paymentId, "chargebacks");
+    }
+}

--- a/src/main/java/nl/stil4m/mollie/domain/Chargeback.java
+++ b/src/main/java/nl/stil4m/mollie/domain/Chargeback.java
@@ -1,0 +1,55 @@
+package nl.stil4m.mollie.domain;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Date;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Chargeback {
+
+    private final String id;
+
+    private final String payment;
+
+    private final Double amount;
+
+    private final Date chargebackDatetime;
+
+    private final Date reversedDatetime;
+
+    @JsonCreator
+    public Chargeback(@JsonProperty("id") String id,
+            @JsonProperty("payment") String payment,
+            @JsonProperty("amount") Double amount,
+            @JsonProperty("status") String status,
+            @JsonProperty("chargebackDatetime") Date chargebackDatetime,
+            @JsonProperty("reversedDatetime") Date reversedDatetime) {
+        this.id = id;
+        this.payment = payment;
+        this.amount = amount;
+        this.chargebackDatetime = chargebackDatetime;
+        this.reversedDatetime = reversedDatetime;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getPayment() {
+        return payment;
+    }
+
+    public Double getAmount() {
+        return amount;
+    }
+
+    public Date getChargebackDatetime() {
+        return chargebackDatetime;
+    }
+
+    public Date getReversedDatetime() {
+        return reversedDatetime;
+    }
+
+}

--- a/src/main/java/nl/stil4m/mollie/domain/Chargeback.java
+++ b/src/main/java/nl/stil4m/mollie/domain/Chargeback.java
@@ -3,6 +3,7 @@ package nl.stil4m.mollie.domain;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.util.Date;
 
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/java/nl/stil4m/mollie/domain/CreateSubscription.java
+++ b/src/main/java/nl/stil4m/mollie/domain/CreateSubscription.java
@@ -1,0 +1,97 @@
+package nl.stil4m.mollie.domain;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import java.util.Date;
+import java.util.Optional;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * @see https://www.mollie.com/en/docs/reference/subscriptions/create
+ * @author stevensnoeijen
+ */
+public class CreateSubscription {
+
+    /**
+     * The constant amount in EURO that you want to charge with each subscription payment, e.g. 100.00 if you would want to charge €100.00.
+     */
+    private Double amount;
+
+    /**
+     * Optional – Total number of charges for the subscription to complete. Leave empty for an ongoing subscription.
+     */
+    private Optional<Integer> times;
+
+    /**
+     * Interval to wait between charges like 1 month(s) or 14 days.
+     * <br/>
+     * Possible values: … months, … weeks, … days
+     */
+    private String interval;
+
+    /**
+     * Optional – The start date of the subscription in yyyy-mm-dd format. This is the first day on which your customer will be charged. When this parameter is not provided, the current date will be used instead.
+     */
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+    private Optional<Date> startDate;
+
+    /**
+     * A description unique per customer. This will be included in the payment description along with the charge date in yyyy-mm-dd format.
+     */
+    private String description;
+
+    /**
+     * Optional – The payment method used for this subscription, either forced on creation or null if any of the customer's valid mandates may be used.
+     * <br/>
+     * Possible values: creditcard, directdebit, null
+     */
+    private Optional<String> method;
+
+    /**
+     * Optional – Use this parameter to set a webhook URL for all subscription payments.
+     */
+    private Optional<String> webhookUrl;
+
+    public CreateSubscription(@Nonnull Double amount, @Nullable Integer times, @Nonnull String interval, @Nullable Date startDate, @Nonnull String description, @Nullable String method, @Nullable String webhookUrl) {
+        super();
+        this.amount = amount;
+        this.times = Optional.ofNullable(times);
+        this.interval = interval;
+        this.startDate = Optional.ofNullable(startDate);
+        this.description = description;
+        this.method = Optional.ofNullable(method);
+        this.webhookUrl = Optional.ofNullable(webhookUrl);
+    }
+
+    public CreateSubscription(@Nonnull Double amount, @Nonnull String interval, @Nonnull String description) {
+        this(amount, null, interval, null, description, null, null);
+    }
+
+    public Double getAmount() {
+        return amount;
+    }
+
+    public Optional<Integer> getTimes() {
+        return times;
+    }
+
+    public String getInterval() {
+        return interval;
+    }
+
+    public Optional<Date> getStartDate() {
+        return startDate;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public Optional<String> getMethod() {
+        return method;
+    }
+
+    public Optional<String> getWebhookUrl() {
+        return webhookUrl;
+    }
+}

--- a/src/main/java/nl/stil4m/mollie/domain/CreateSubscription.java
+++ b/src/main/java/nl/stil4m/mollie/domain/CreateSubscription.java
@@ -1,7 +1,5 @@
 package nl.stil4m.mollie.domain;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
-import java.util.Date;
 import java.util.Optional;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -32,8 +30,7 @@ public class CreateSubscription {
     /**
      * Optional – The start date of the subscription in yyyy-mm-dd format. This is the first day on which your customer will be charged. When this parameter is not provided, the current date will be used instead.
      */
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
-    private Optional<Date> startDate;
+    private Optional<String> startDate;
 
     /**
      * A description unique per customer. This will be included in the payment description along with the charge date in yyyy-mm-dd format.
@@ -52,7 +49,7 @@ public class CreateSubscription {
      */
     private Optional<String> webhookUrl;
 
-    public CreateSubscription(@Nonnull Double amount, @Nullable Integer times, @Nonnull String interval, @Nullable Date startDate, @Nonnull String description, @Nullable String method, @Nullable String webhookUrl) {
+    public CreateSubscription(@Nonnull Double amount, @Nullable Integer times, @Nonnull String interval, @Nullable String startDate, @Nonnull String description, @Nullable String method, @Nullable String webhookUrl) {
         super();
         this.amount = amount;
         this.times = Optional.ofNullable(times);
@@ -79,7 +76,7 @@ public class CreateSubscription {
         return interval;
     }
 
-    public Optional<Date> getStartDate() {
+    public Optional<String> getStartDate() {
         return startDate;
     }
 

--- a/src/main/java/nl/stil4m/mollie/domain/CreateSubscription.java
+++ b/src/main/java/nl/stil4m/mollie/domain/CreateSubscription.java
@@ -6,7 +6,6 @@ import javax.annotation.Nullable;
 
 /**
  * @see https://www.mollie.com/en/docs/reference/subscriptions/create
- * @author stevensnoeijen
  */
 public class CreateSubscription {
 

--- a/src/main/java/nl/stil4m/mollie/domain/CreateSubscription.java
+++ b/src/main/java/nl/stil4m/mollie/domain/CreateSubscription.java
@@ -1,8 +1,8 @@
 package nl.stil4m.mollie.domain;
 
-import java.util.Optional;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.Optional;
 
 /**
  * @see https://www.mollie.com/en/docs/reference/subscriptions/create

--- a/src/main/java/nl/stil4m/mollie/domain/CreateSubscription.java
+++ b/src/main/java/nl/stil4m/mollie/domain/CreateSubscription.java
@@ -28,7 +28,8 @@ public class CreateSubscription {
     private String interval;
 
     /**
-     * Optional – The start date of the subscription in yyyy-mm-dd format. This is the first day on which your customer will be charged. When this parameter is not provided, the current date will be used instead.
+     * Optional – The start date of the subscription in yyyy-mm-dd format. This is the first day on which your customer will be charged. When this
+     * parameter is not provided, the current date will be used instead.
      */
     private Optional<String> startDate;
 
@@ -38,7 +39,8 @@ public class CreateSubscription {
     private String description;
 
     /**
-     * Optional – The payment method used for this subscription, either forced on creation or null if any of the customer's valid mandates may be used.
+     * Optional – The payment method used for this subscription, either forced on creation or null if any of the customer's valid mandates may be
+     * used.
      * <br/>
      * Possible values: creditcard, directdebit, null
      */
@@ -50,7 +52,6 @@ public class CreateSubscription {
     private Optional<String> webhookUrl;
 
     public CreateSubscription(@Nonnull Double amount, @Nullable Integer times, @Nonnull String interval, @Nullable String startDate, @Nonnull String description, @Nullable String method, @Nullable String webhookUrl) {
-        super();
         this.amount = amount;
         this.times = Optional.ofNullable(times);
         this.interval = interval;

--- a/src/main/java/nl/stil4m/mollie/domain/Issuer.java
+++ b/src/main/java/nl/stil4m/mollie/domain/Issuer.java
@@ -1,8 +1,8 @@
 package nl.stil4m.mollie.domain;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 @JsonIgnoreProperties(value={ "image" })
 public class Issuer {

--- a/src/main/java/nl/stil4m/mollie/domain/Payment.java
+++ b/src/main/java/nl/stil4m/mollie/domain/Payment.java
@@ -2,12 +2,11 @@ package nl.stil4m.mollie.domain;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-
 import java.util.Date;
 import java.util.Map;
 import java.util.Optional;
 
-@JsonIgnoreProperties(value = { "issuer" })
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class Payment {
 
     private final String resource;
@@ -18,9 +17,10 @@ public class Payment {
     private final String recurringType;
     private final Date createdDatetime;
     private final String status;
-    private final String paidDatetime;
-    private final String cancelledDatetime;
-    private final String expiredDatetime;
+    private final Date paidDatetime;
+    private final Date cancelledDatetime;
+    private final Date expiredDatetime;
+    private final Date failedDatetime;
     private final Double amount;
     private final Double amountRefunded;
     private final Double amountRemaining;
@@ -36,29 +36,30 @@ public class Payment {
     private final Optional<Boolean> canBeCancelled;
 
     public Payment(@JsonProperty("resource") String resource,
-                   @JsonProperty("id") String id,
-                   @JsonProperty("profileId") String profileId,
-                   @JsonProperty("mode") String mode,
-                   @JsonProperty("customerId") String customerId,
-                   @JsonProperty("recurringType") String recurringType,
-                   @JsonProperty("createdDatetime") Date createdDatetime,
-                   @JsonProperty("status") String status,
-                   @JsonProperty("paidDatetime") String paidDatetime,
-                   @JsonProperty("cancelledDatetime") String cancelledDatetime,
-                   @JsonProperty("expiredDatetime") String expiredDatetime,
-                   @JsonProperty("amount") Double amount,
-                   @JsonProperty("amountRefunded") Double amountRefunded,
-                   @JsonProperty("amountRemaining") Double amountRemaining,
-                   @JsonProperty("description") String description,
-                   @JsonProperty("method") String method,
-                   @JsonProperty("details") Map<String, Object> details,
-                   @JsonProperty("links") Links links,
-                   @JsonProperty("metadata") Map<String, Object> metadata,
-                   @JsonProperty("locale") String locale,
-                   @JsonProperty("countryCode") String countryCode,
-                   @JsonProperty("expiryPeriod") String expiryPeriod,
-                   @JsonProperty("mandateId") Optional<String> mandateId,
-                   @JsonProperty("canBeCancelled") Optional<Boolean> canBeCancelled) {
+            @JsonProperty("id") String id,
+            @JsonProperty("profileId") String profileId,
+            @JsonProperty("mode") String mode,
+            @JsonProperty("customerId") String customerId,
+            @JsonProperty("recurringType") String recurringType,
+            @JsonProperty("createdDatetime") Date createdDatetime,
+            @JsonProperty("status") String status,
+            @JsonProperty("paidDatetime") Date paidDatetime,
+            @JsonProperty("cancelledDatetime") Date cancelledDatetime,
+            @JsonProperty("expiredDatetime") Date expiredDatetime,
+            @JsonProperty("amount") Double amount,
+            @JsonProperty("amountRefunded") Double amountRefunded,
+            @JsonProperty("amountRemaining") Double amountRemaining,
+            @JsonProperty("description") String description,
+            @JsonProperty("method") String method,
+            @JsonProperty("details") Map<String, Object> details,
+            @JsonProperty("links") Links links,
+            @JsonProperty("metadata") Map<String, Object> metadata,
+            @JsonProperty("locale") String locale,
+            @JsonProperty("countryCode") String countryCode,
+            @JsonProperty("expiryPeriod") String expiryPeriod,
+            @JsonProperty("mandateId") Optional<String> mandateId,
+            @JsonProperty("canBeCancelled") Optional<Boolean> canBeCancelled,
+            @JsonProperty("failedDatetime") Date failedDatetime) {
         this.resource = resource;
         this.id = id;
         this.profileId = profileId;
@@ -83,6 +84,7 @@ public class Payment {
         this.expiryPeriod = expiryPeriod;
         this.mandateId = mandateId;
         this.canBeCancelled = canBeCancelled;
+        this.failedDatetime = failedDatetime;
     }
 
     public String getResource() {
@@ -117,15 +119,15 @@ public class Payment {
         return status;
     }
 
-    public String getPaidDatetime() {
+    public Date getPaidDatetime() {
         return paidDatetime;
     }
 
-    public String getCancelledDatetime() {
+    public Date getCancelledDatetime() {
         return cancelledDatetime;
     }
 
-    public String getExpiredDatetime() {
+    public Date getExpiredDatetime() {
         return expiredDatetime;
     }
 

--- a/src/main/java/nl/stil4m/mollie/domain/Payment.java
+++ b/src/main/java/nl/stil4m/mollie/domain/Payment.java
@@ -182,4 +182,8 @@ public class Payment {
     public Optional<Boolean> geCanBeCancelled() {
         return canBeCancelled;
     }
+
+    public Date getFailedDatetime() {
+        return failedDatetime;
+    }
 }

--- a/src/main/java/nl/stil4m/mollie/domain/Payment.java
+++ b/src/main/java/nl/stil4m/mollie/domain/Payment.java
@@ -2,6 +2,7 @@ package nl.stil4m.mollie.domain;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.util.Date;
 import java.util.Map;
 import java.util.Optional;

--- a/src/main/java/nl/stil4m/mollie/domain/Payment.java
+++ b/src/main/java/nl/stil4m/mollie/domain/Payment.java
@@ -2,7 +2,6 @@ package nl.stil4m.mollie.domain;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-
 import java.util.Date;
 import java.util.Map;
 import java.util.Optional;
@@ -35,6 +34,7 @@ public class Payment {
     private final String expiryPeriod;
     private final Optional<String> mandateId;
     private final Optional<Boolean> canBeCancelled;
+    private final String subscriptionId;
 
     public Payment(@JsonProperty("resource") String resource,
             @JsonProperty("id") String id,
@@ -60,7 +60,8 @@ public class Payment {
             @JsonProperty("expiryPeriod") String expiryPeriod,
             @JsonProperty("mandateId") Optional<String> mandateId,
             @JsonProperty("canBeCancelled") Optional<Boolean> canBeCancelled,
-            @JsonProperty("failedDatetime") Date failedDatetime) {
+            @JsonProperty("failedDatetime") Date failedDatetime,
+            @JsonProperty("subscriptionId") String subscriptionId) {
         this.resource = resource;
         this.id = id;
         this.profileId = profileId;
@@ -86,6 +87,7 @@ public class Payment {
         this.mandateId = mandateId;
         this.canBeCancelled = canBeCancelled;
         this.failedDatetime = failedDatetime;
+        this.subscriptionId = subscriptionId;
     }
 
     public String getResource() {
@@ -186,5 +188,9 @@ public class Payment {
 
     public Date getFailedDatetime() {
         return failedDatetime;
+    }
+
+    public String getSubscriptionId() {
+        return subscriptionId;
     }
 }

--- a/src/main/java/nl/stil4m/mollie/domain/Refund.java
+++ b/src/main/java/nl/stil4m/mollie/domain/Refund.java
@@ -1,10 +1,11 @@
 package nl.stil4m.mollie.domain;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-
 import java.util.Date;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class Refund {
 
     private final String id;
@@ -21,11 +22,11 @@ public class Refund {
 
     @JsonCreator
     public Refund(@JsonProperty("id") String id,
-                  @JsonProperty("payment") Payment payment,
-                  @JsonProperty("amount") Double amount,
-                  @JsonProperty("status") String status,
-                  @JsonProperty("refundedDatetime") Date refundedDatetime,
-                  @JsonProperty("links") RefundLinks links) {
+            @JsonProperty("payment") Payment payment,
+            @JsonProperty("amount") Double amount,
+            @JsonProperty("status") String status,
+            @JsonProperty("refundedDatetime") Date refundedDatetime,
+            @JsonProperty("links") RefundLinks links) {
         this.id = id;
         this.payment = payment;
         this.amount = amount;

--- a/src/main/java/nl/stil4m/mollie/domain/Refund.java
+++ b/src/main/java/nl/stil4m/mollie/domain/Refund.java
@@ -3,6 +3,7 @@ package nl.stil4m.mollie.domain;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.util.Date;
 
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/java/nl/stil4m/mollie/domain/Subscription.java
+++ b/src/main/java/nl/stil4m/mollie/domain/Subscription.java
@@ -1,0 +1,179 @@
+package nl.stil4m.mollie.domain;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Date;
+
+/**
+ * @see https://www.mollie.com/en/docs/reference/subscriptions/get
+ * @author stevensnoeijen
+ */
+public class Subscription {
+
+    /**
+     * Indicates the response contains a subscription object.
+     * <br/>
+     * Possible values: subscription
+     */
+    private String resource;
+
+    /**
+     * The subscription's unique identifier, for example sub_rVKGtNd6s3.
+     */
+    private String id;
+
+    /**
+     * The customer's unique identifier, for example cst_stTC2WHAuS.
+     */
+    private String customerId;
+
+    /**
+     * The mode used to create this subscription.Mode determines whether the payments are real or test payments.
+     * <br/>
+     * Possible values: live, test
+     */
+    private String mode;
+
+    /**
+     * The subscription's date and time of creation, in ISO 8601 format.
+     */
+    private Date createdDatetime;
+
+    /**
+     * The subscription's current status, depends on whether the customer has a pending, valid or invalid mandate.
+     * <br/>
+     * Possible values: pending, active, cancelled, suspended, completed
+     */
+    private String status;
+
+    /**
+     * The constant amount that is charged with each subscription payment
+     */
+    private Double amount;
+
+    /**
+     * Total number of charges for the subscription to complete
+     */
+    private Integer times;
+
+    /**
+     * Interval to wait between charges like 1 month(s) or 14 days.
+     * <br/>
+     * Possible values: … months, … weeks, … days.
+     */
+    private String interval;
+
+    /**
+     * The start date of the subscription in yyyy-mm-dd format.
+     */
+    private Date startDate;
+
+    /**
+     * A description unique per customer. This will be included in the payment description along with the charge date in yyyy-mm-dd format.
+     */
+    private String description;
+
+    /**
+     * The payment method used for this subscription, either forced on creation by specifying the method parameter, or null if any of the customer's valid mandates may be used.
+     * <br/>
+     * Possible values: creditcard, directdebit, null
+     */
+    private String method;
+
+    /**
+     * The subscription's date of cancellation, in ISO 8601 format.
+     */
+    private Date cancelledDatetime;
+
+    /**
+     * An object with URLs important to the payment process.
+     * Only webhookUrl can be set.
+     */
+    private Links links;
+
+    public Subscription(@JsonProperty("resource") String resource,
+            @JsonProperty("id") String id,
+            @JsonProperty("customerId") String customerId,
+            @JsonProperty("mode") String mode,
+            @JsonProperty("createdDatetime") Date createdDatetime,
+            @JsonProperty("status") String status,
+            @JsonProperty("amount") Double amount,
+            @JsonProperty("times") Integer times,
+            @JsonProperty("interval") String interval,
+            @JsonProperty("startDate") Date startDate,
+            @JsonProperty("description") String description,
+            @JsonProperty("method") String method,
+            @JsonProperty("cancelledDatetime") Date cancelledDatetime,
+            @JsonProperty("links") Links links) {
+        this.resource = resource;
+        this.id = id;
+        this.customerId = customerId;
+        this.mode = mode;
+        this.createdDatetime = createdDatetime;
+        this.status = status;
+        this.amount = amount;
+        this.times = times;
+        this.interval = interval;
+        this.startDate = startDate;
+        this.description = description;
+        this.method = method;
+        this.cancelledDatetime = cancelledDatetime;
+        this.links = links;
+    }
+
+    public String getResource() {
+        return resource;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getCustomerId() {
+        return customerId;
+    }
+
+    public String getMode() {
+        return mode;
+    }
+
+    public Date getCreatedDatetime() {
+        return createdDatetime;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public Double getAmount() {
+        return amount;
+    }
+
+    public Integer getTimes() {
+        return times;
+    }
+
+    public String getInterval() {
+        return interval;
+    }
+
+    public Date getStartDate() {
+        return startDate;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public String getMethod() {
+        return method;
+    }
+
+    public Date getCancelledDatetime() {
+        return cancelledDatetime;
+    }
+
+    public Links getLinks() {
+        return links;
+    }
+
+}

--- a/src/main/java/nl/stil4m/mollie/domain/Subscription.java
+++ b/src/main/java/nl/stil4m/mollie/domain/Subscription.java
@@ -1,6 +1,7 @@
 package nl.stil4m.mollie.domain;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.util.Date;
 
 /**

--- a/src/main/java/nl/stil4m/mollie/domain/Subscription.java
+++ b/src/main/java/nl/stil4m/mollie/domain/Subscription.java
@@ -5,7 +5,6 @@ import java.util.Date;
 
 /**
  * @see https://www.mollie.com/en/docs/reference/subscriptions/get
- * @author stevensnoeijen
  */
 public class Subscription {
 
@@ -73,7 +72,8 @@ public class Subscription {
     private String description;
 
     /**
-     * The payment method used for this subscription, either forced on creation by specifying the method parameter, or null if any of the customer's valid mandates may be used.
+     * The payment method used for this subscription, either forced on creation by specifying the method parameter, or null if any of the customer's
+     * valid mandates may be used.
      * <br/>
      * Possible values: creditcard, directdebit, null
      */
@@ -85,8 +85,7 @@ public class Subscription {
     private Date cancelledDatetime;
 
     /**
-     * An object with URLs important to the payment process.
-     * Only webhookUrl can be set.
+     * An object with URLs important to the payment process. Only webhookUrl can be set.
      */
     private Links links;
 

--- a/src/main/java/nl/stil4m/mollie/domain/UpdateCustomer.java
+++ b/src/main/java/nl/stil4m/mollie/domain/UpdateCustomer.java
@@ -7,7 +7,7 @@ import java.util.Map;
 import java.util.Optional;
 
 
-@JsonInclude(value = JsonInclude.Include.NON_ABSENT, content = JsonInclude.Include.NON_EMPTY)
+@JsonInclude(value = JsonInclude.Include.NON_DEFAULT, content = JsonInclude.Include.NON_EMPTY)
 public class UpdateCustomer {
 
 

--- a/src/main/java/nl/stil4m/mollie/domain/UpdateCustomer.java
+++ b/src/main/java/nl/stil4m/mollie/domain/UpdateCustomer.java
@@ -7,7 +7,7 @@ import java.util.Map;
 import java.util.Optional;
 
 
-@JsonInclude(value = JsonInclude.Include.NON_DEFAULT, content = JsonInclude.Include.NON_EMPTY)
+@JsonInclude(content = JsonInclude.Include.NON_EMPTY)
 public class UpdateCustomer {
 
 

--- a/src/test/java/nl/stil4m/mollie/concepts/CustomerMandatesIntegrationTest.java
+++ b/src/test/java/nl/stil4m/mollie/concepts/CustomerMandatesIntegrationTest.java
@@ -23,7 +23,6 @@ import static nl.stil4m.mollie.TestUtil.strictClientWithApiKey;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.nullValue;
 
 public class CustomerMandatesIntegrationTest {
 

--- a/src/test/java/nl/stil4m/mollie/concepts/CustomerSubscriptionsIntegrationTest.java
+++ b/src/test/java/nl/stil4m/mollie/concepts/CustomerSubscriptionsIntegrationTest.java
@@ -4,32 +4,50 @@ import io.github.bonigarcia.wdm.ChromeDriverManager;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.text.SimpleDateFormat;
-import java.util.*;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
 import nl.stil4m.mollie.Client;
 import nl.stil4m.mollie.ResponseOrError;
-import nl.stil4m.mollie.domain.*;
+import static nl.stil4m.mollie.TestUtil.TEST_TIMEOUT;
+import static nl.stil4m.mollie.TestUtil.VALID_API_KEY;
+import static nl.stil4m.mollie.TestUtil.strictClientWithApiKey;
+import nl.stil4m.mollie.domain.CreateCustomer;
+import nl.stil4m.mollie.domain.CreatePayment;
+import nl.stil4m.mollie.domain.CreateSubscription;
+import nl.stil4m.mollie.domain.Customer;
+import nl.stil4m.mollie.domain.Page;
+import nl.stil4m.mollie.domain.Payment;
+import nl.stil4m.mollie.domain.Subscription;
 import nl.stil4m.mollie.domain.customerpayments.FirstRecurringPayment;
 import nl.stil4m.mollie.domain.subpayments.ideal.CreateIdealPayment;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import org.junit.After;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.chrome.ChromeDriver;
 
-import static nl.stil4m.mollie.TestUtil.TEST_TIMEOUT;
-import static nl.stil4m.mollie.TestUtil.VALID_API_KEY;
-import static nl.stil4m.mollie.TestUtil.strictClientWithApiKey;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
-
 public class CustomerSubscriptionsIntegrationTest {
 
     private CustomerPayments customerPayments;
     private CustomerSubscriptions customerSubscriptions;
+    private WebDriver driver;
+
+    @BeforeClass
+    public static void setupClass() {
+        //setup selenium
+        ChromeDriverManager.getInstance().setup();
+    }
 
     @Before
     public void before() throws InterruptedException, IOException {
@@ -47,8 +65,13 @@ public class CustomerSubscriptionsIntegrationTest {
         customerPayments = client.customerPayments(customer.getId());
         customerSubscriptions = client.customerSubscriptions(customer.getId());
 
-        //setup selenium
-        ChromeDriverManager.getInstance().setup();
+        //create new selenium driver
+        driver = new ChromeDriver();
+    }
+
+    @After
+    public void after() {
+        driver.quit();
     }
 
     @Test
@@ -69,10 +92,7 @@ public class CustomerSubscriptionsIntegrationTest {
         String paymentUrl = payment.getLinks().getPaymentUrl();
 
         //open paymentUrl and set it to paid
-
-        //setup selenium
-        WebDriver driver = new ChromeDriver();
-
+        //open payment link
         driver.get(paymentUrl);
         // Find ok button and click it
         driver.findElement(By.name("issuer")).click();
@@ -86,8 +106,6 @@ public class CustomerSubscriptionsIntegrationTest {
 
         //submit form
         driver.findElement(By.cssSelector("#footer > button")).click();
-
-        driver.quit();
 
         //check if payment is complete
         payment = customerPayments.get(payment.getId()).getData();//get new version of payment
@@ -128,7 +146,6 @@ public class CustomerSubscriptionsIntegrationTest {
         String paymentUrl = payment.getLinks().getPaymentUrl();
 
         //open paymentUrl and set it to paid
-
         //setup selenium
         WebDriver driver = new ChromeDriver();
 
@@ -145,8 +162,6 @@ public class CustomerSubscriptionsIntegrationTest {
 
         //submit form
         driver.findElement(By.cssSelector("#footer > button")).click();
-
-        driver.quit();
 
         //check if payment is complete
         payment = customerPayments.get(payment.getId()).getData();//get new version of payment

--- a/src/test/java/nl/stil4m/mollie/concepts/CustomerSubscriptionsIntegrationTest.java
+++ b/src/test/java/nl/stil4m/mollie/concepts/CustomerSubscriptionsIntegrationTest.java
@@ -1,19 +1,8 @@
 package nl.stil4m.mollie.concepts;
 
 import io.github.bonigarcia.wdm.ChromeDriverManager;
-import java.io.IOException;
-import java.net.URISyntaxException;
-import java.text.SimpleDateFormat;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Optional;
-import java.util.UUID;
 import nl.stil4m.mollie.Client;
 import nl.stil4m.mollie.ResponseOrError;
-import static nl.stil4m.mollie.TestUtil.TEST_TIMEOUT;
-import static nl.stil4m.mollie.TestUtil.VALID_API_KEY;
-import static nl.stil4m.mollie.TestUtil.strictClientWithApiKey;
 import nl.stil4m.mollie.domain.CreateCustomer;
 import nl.stil4m.mollie.domain.CreatePayment;
 import nl.stil4m.mollie.domain.CreateSubscription;
@@ -23,19 +12,32 @@ import nl.stil4m.mollie.domain.Payment;
 import nl.stil4m.mollie.domain.Subscription;
 import nl.stil4m.mollie.domain.customerpayments.FirstRecurringPayment;
 import nl.stil4m.mollie.domain.subpayments.ideal.CreateIdealPayment;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.notNullValue;
 import org.junit.After;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.chrome.ChromeDriver;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import static nl.stil4m.mollie.TestUtil.TEST_TIMEOUT;
+import static nl.stil4m.mollie.TestUtil.VALID_API_KEY;
+import static nl.stil4m.mollie.TestUtil.strictClientWithApiKey;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
 
 public class CustomerSubscriptionsIntegrationTest {
 

--- a/src/test/java/nl/stil4m/mollie/concepts/CustomerSubscriptionsIntegrationTest.java
+++ b/src/test/java/nl/stil4m/mollie/concepts/CustomerSubscriptionsIntegrationTest.java
@@ -3,6 +3,7 @@ package nl.stil4m.mollie.concepts;
 import io.github.bonigarcia.wdm.ChromeDriverManager;
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.text.SimpleDateFormat;
 import java.util.*;
 import nl.stil4m.mollie.Client;
 import nl.stil4m.mollie.ResponseOrError;
@@ -100,7 +101,7 @@ public class CustomerSubscriptionsIntegrationTest {
         String description = "test subscription";
         String webhookUrl = "https://example.com/api/payment";
 
-        CreateSubscription createSubscription = new CreateSubscription(amount, times, interval, startDate, description, null, webhookUrl);
+        CreateSubscription createSubscription = new CreateSubscription(amount, times, interval, new SimpleDateFormat("yyyy-MM-dd").format(startDate), description, null, webhookUrl);
 
         ResponseOrError<Subscription> result = customerSubscriptions.create(createSubscription);
 

--- a/src/test/java/nl/stil4m/mollie/concepts/CustomerSubscriptionsIntegrationTest.java
+++ b/src/test/java/nl/stil4m/mollie/concepts/CustomerSubscriptionsIntegrationTest.java
@@ -1,0 +1,115 @@
+package nl.stil4m.mollie.concepts;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.*;
+import nl.stil4m.mollie.Client;
+import nl.stil4m.mollie.ResponseOrError;
+import nl.stil4m.mollie.domain.*;
+import nl.stil4m.mollie.domain.customerpayments.FirstRecurringPayment;
+import nl.stil4m.mollie.domain.subpayments.ideal.CreateIdealPayment;
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.chrome.ChromeDriver;
+
+import static nl.stil4m.mollie.TestUtil.TEST_TIMEOUT;
+import static nl.stil4m.mollie.TestUtil.VALID_API_KEY;
+import static nl.stil4m.mollie.TestUtil.strictClientWithApiKey;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.fail;
+
+public class CustomerSubscriptionsIntegrationTest {
+
+    private CustomerPayments customerPayments;
+    private CustomerSubscriptions customerSubscriptions;
+
+    @Before
+    public void before() throws InterruptedException, IOException {
+        Thread.sleep(TEST_TIMEOUT);
+        Client client = strictClientWithApiKey(VALID_API_KEY);
+
+        String uuid = UUID.randomUUID().toString();
+        Map<String, Object> defaultMetadata = new HashMap<>();
+        defaultMetadata.put("foo", "bar");
+        defaultMetadata.put("id", uuid);
+
+        String name = "Test Customer " + uuid;
+        Customer customer = client.customers().create(new CreateCustomer(name, uuid + "@foobar.com", Optional.empty(), defaultMetadata)).getData();
+
+        customerPayments = client.customerPayments(customer.getId());
+        customerSubscriptions = client.customerSubscriptions(customer.getId());
+
+        //setup selenium
+        System.setProperty("webdriver.chrome.driver", "chromedriver");
+    }
+
+    @Test
+    public void testList() throws IOException, URISyntaxException {
+        ResponseOrError<Page<Subscription>> list = customerSubscriptions.list(Optional.empty(), Optional.empty());
+
+        assertThat(list.getSuccess(), is(true));
+    }
+
+    @Test
+    public void testCreate() throws IOException, URISyntaxException, InterruptedException {
+        // https://www.mollie.com/en/docs/reference/subscriptions/create
+        //create payment that creates membate (required to create subscription), this is kinda a confirm for the payment info to do the recurring payment over
+        CreatePayment createIdealPayment = new CreateIdealPayment(10d, "test payment for subscription", "https://example.com/thank/you", Optional.empty(), null, null);
+        FirstRecurringPayment customerPayment = new FirstRecurringPayment(createIdealPayment);
+        Payment payment = customerPayments.create(customerPayment).getData();
+
+        String paymentUrl = payment.getLinks().getPaymentUrl();
+
+        //open paymentUrl and set it to paid
+
+        //setup selenium
+        WebDriver driver = new ChromeDriver();
+
+        driver.get(paymentUrl);
+        // Find ok button and click it
+        driver.findElement(By.name("issuer")).click();
+
+        //find "paid" radiobutton and click it
+        driver.findElements(By.name("final_state")).forEach(radioButton -> {
+            if (radioButton.getAttribute("value").equals("paid")) {
+                radioButton.click();
+            }
+        });
+
+        //submit form
+        driver.findElement(By.cssSelector("#footer > button")).click();
+
+        driver.quit();
+
+        //check if payment is complete
+        payment = customerPayments.get(payment.getId()).getData();//get new version of payment
+        if (!payment.getStatus().equals("paid")) {
+            fail("completing payment failed");
+            return;
+        }
+
+        Double amount = 10d;
+        Integer times = 2;
+        String interval = "7 days";
+        Date startDate = new Date();
+        String description = "test subscription";
+        String webhookUrl = "https://example.com/api/payment";
+
+        CreateSubscription createSubscription = new CreateSubscription(amount, times, interval, startDate, description, null, webhookUrl);
+
+        ResponseOrError<Subscription> result = customerSubscriptions.create(createSubscription);
+
+        assertThat(result.getSuccess(), is(true));
+        assertThat(result.getData().getId(), notNullValue());
+        assertThat(result.getData().getAmount(), is(amount));
+        assertThat(result.getData().getTimes(), is(times));
+        assertThat(result.getData().getInterval(), is(interval));
+        assertThat(result.getData().getStartDate(), notNullValue());//time will differ due to timezone-stuff
+        assertThat(result.getData().getDescription(), is(description));
+        assertThat(result.getData().getLinks().getWebhookUrl(), is(webhookUrl));
+    }
+}

--- a/src/test/java/nl/stil4m/mollie/concepts/CustomerSubscriptionsIntegrationTest.java
+++ b/src/test/java/nl/stil4m/mollie/concepts/CustomerSubscriptionsIntegrationTest.java
@@ -1,5 +1,6 @@
 package nl.stil4m.mollie.concepts;
 
+import io.github.bonigarcia.wdm.ChromeDriverManager;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.*;
@@ -44,7 +45,7 @@ public class CustomerSubscriptionsIntegrationTest {
         customerSubscriptions = client.customerSubscriptions(customer.getId());
 
         //setup selenium
-        System.setProperty("webdriver.chrome.driver", "chromedriver");
+        ChromeDriverManager.getInstance().setup();
     }
 
     @Test

--- a/src/test/java/nl/stil4m/mollie/concepts/IssuersIntegrationTest.java
+++ b/src/test/java/nl/stil4m/mollie/concepts/IssuersIntegrationTest.java
@@ -1,25 +1,24 @@
 package nl.stil4m.mollie.concepts;
 
-import nl.stil4m.mollie.ResponseOrError;
-import nl.stil4m.mollie.domain.Issuer;
-import nl.stil4m.mollie.domain.Page;
-import org.junit.Before;
-import org.junit.Test;
-
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
-
+import nl.stil4m.mollie.ResponseOrError;
 import static nl.stil4m.mollie.TestUtil.TEST_ISSUER;
 import static nl.stil4m.mollie.TestUtil.TEST_TIMEOUT;
 import static nl.stil4m.mollie.TestUtil.VALID_API_KEY;
 import static nl.stil4m.mollie.TestUtil.strictClientWithApiKey;
+import nl.stil4m.mollie.domain.Issuer;
+import nl.stil4m.mollie.domain.Page;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
 
 public class IssuersIntegrationTest {
 
@@ -32,6 +31,7 @@ public class IssuersIntegrationTest {
     }
 
     @Test
+    @Ignore
     public void testGetIssuers() throws IOException, URISyntaxException, InterruptedException {
         ResponseOrError<Page<Issuer>> allResponse = issuers.all(Optional.empty(), Optional.empty());
 
@@ -50,6 +50,7 @@ public class IssuersIntegrationTest {
     }
 
     @Test
+    @Ignore
     public void testGetIssuer() throws IOException, URISyntaxException, InterruptedException {
         ResponseOrError<Issuer> allResponse = issuers.get(TEST_ISSUER);
 

--- a/src/test/java/nl/stil4m/mollie/concepts/IssuersIntegrationTest.java
+++ b/src/test/java/nl/stil4m/mollie/concepts/IssuersIntegrationTest.java
@@ -1,24 +1,26 @@
 package nl.stil4m.mollie.concepts;
 
+import nl.stil4m.mollie.ResponseOrError;
+import nl.stil4m.mollie.domain.Issuer;
+import nl.stil4m.mollie.domain.Page;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
-import nl.stil4m.mollie.ResponseOrError;
+
 import static nl.stil4m.mollie.TestUtil.TEST_ISSUER;
 import static nl.stil4m.mollie.TestUtil.TEST_TIMEOUT;
 import static nl.stil4m.mollie.TestUtil.VALID_API_KEY;
 import static nl.stil4m.mollie.TestUtil.strictClientWithApiKey;
-import nl.stil4m.mollie.domain.Issuer;
-import nl.stil4m.mollie.domain.Page;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
 
 public class IssuersIntegrationTest {
 

--- a/src/test/java/nl/stil4m/mollie/concepts/MethodsIntegrationTest.java
+++ b/src/test/java/nl/stil4m/mollie/concepts/MethodsIntegrationTest.java
@@ -18,10 +18,10 @@ import static nl.stil4m.mollie.TestUtil.VALID_API_KEY;
 import static nl.stil4m.mollie.TestUtil.strictClientWithApiKey;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItem;
-import static org.hamcrest.Matchers.startsWith;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.startsWith;
 
 public class MethodsIntegrationTest {
 

--- a/src/test/java/nl/stil4m/mollie/concepts/PaymentsIntegrationTest.java
+++ b/src/test/java/nl/stil4m/mollie/concepts/PaymentsIntegrationTest.java
@@ -1,17 +1,7 @@
 package nl.stil4m.mollie.concepts;
 
-import java.io.IOException;
-import java.net.URISyntaxException;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Optional;
 import nl.stil4m.mollie.Client;
 import nl.stil4m.mollie.ResponseOrError;
-import static nl.stil4m.mollie.TestUtil.TEST_TIMEOUT;
-import static nl.stil4m.mollie.TestUtil.VALID_API_KEY;
-import static nl.stil4m.mollie.TestUtil.assertWithin;
-import static nl.stil4m.mollie.TestUtil.strictClientWithApiKey;
 import nl.stil4m.mollie.domain.CreatePayment;
 import nl.stil4m.mollie.domain.Issuer;
 import nl.stil4m.mollie.domain.Page;
@@ -19,15 +9,27 @@ import nl.stil4m.mollie.domain.Payment;
 import nl.stil4m.mollie.domain.subpayments.ideal.CreateIdealPayment;
 import nl.stil4m.mollie.domain.subpayments.ideal.IdealPaymentOptions;
 import org.apache.http.HttpStatus;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static nl.stil4m.mollie.TestUtil.TEST_TIMEOUT;
+import static nl.stil4m.mollie.TestUtil.VALID_API_KEY;
+import static nl.stil4m.mollie.TestUtil.assertWithin;
+import static nl.stil4m.mollie.TestUtil.strictClientWithApiKey;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.fail;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
 
 public class PaymentsIntegrationTest {
 

--- a/src/test/java/nl/stil4m/mollie/concepts/RefundsIntegrationTest.java
+++ b/src/test/java/nl/stil4m/mollie/concepts/RefundsIntegrationTest.java
@@ -1,22 +1,21 @@
 package nl.stil4m.mollie.concepts;
 
-import nl.stil4m.mollie.Client;
-import nl.stil4m.mollie.ResponseOrError;
-import nl.stil4m.mollie.domain.Page;
-import nl.stil4m.mollie.domain.Refund;
-import org.junit.Before;
-import org.junit.Test;
-
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.Optional;
-
+import nl.stil4m.mollie.Client;
+import nl.stil4m.mollie.ResponseOrError;
 import static nl.stil4m.mollie.TestUtil.TEST_TIMEOUT;
 import static nl.stil4m.mollie.TestUtil.VALID_API_KEY;
 import static nl.stil4m.mollie.TestUtil.strictClientWithApiKey;
+import nl.stil4m.mollie.domain.Page;
+import nl.stil4m.mollie.domain.Refund;
 import static org.hamcrest.MatcherAssert.assertThat;
+import org.hamcrest.Matchers;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
+import org.junit.Before;
+import org.junit.Test;
 
 public class RefundsIntegrationTest {
 
@@ -35,7 +34,7 @@ public class RefundsIntegrationTest {
 
         assertThat(all.getSuccess(), is(true));
         Page<Refund> refundPage = all.getData();
-        assertThat(refundPage.getCount(), is(0));
+        assertThat(refundPage.getCount(), Matchers.greaterThan(0));
         assertThat(refundPage.getData(), is(notNullValue()));
         assertThat(refundPage.getLinks(), is(notNullValue()));
     }

--- a/src/test/java/nl/stil4m/mollie/concepts/RefundsIntegrationTest.java
+++ b/src/test/java/nl/stil4m/mollie/concepts/RefundsIntegrationTest.java
@@ -1,21 +1,23 @@
 package nl.stil4m.mollie.concepts;
 
+import nl.stil4m.mollie.Client;
+import nl.stil4m.mollie.ResponseOrError;
+import nl.stil4m.mollie.domain.Page;
+import nl.stil4m.mollie.domain.Refund;
+import org.hamcrest.Matchers;
+import org.junit.Before;
+import org.junit.Test;
+
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.Optional;
-import nl.stil4m.mollie.Client;
-import nl.stil4m.mollie.ResponseOrError;
+
 import static nl.stil4m.mollie.TestUtil.TEST_TIMEOUT;
 import static nl.stil4m.mollie.TestUtil.VALID_API_KEY;
 import static nl.stil4m.mollie.TestUtil.strictClientWithApiKey;
-import nl.stil4m.mollie.domain.Page;
-import nl.stil4m.mollie.domain.Refund;
 import static org.hamcrest.MatcherAssert.assertThat;
-import org.hamcrest.Matchers;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
-import org.junit.Before;
-import org.junit.Test;
 
 public class RefundsIntegrationTest {
 


### PR DESCRIPTION
Added concept for Client.customerSubscriptions to create, getById and delete (cancel) subscriptions with tests.

For this I also added:

- Selenium to fully automatic test a payment. I needed this to able to test the creation of a subscription (which requires a first payment).

- DeleteWithResponse, due to the Delete-concept would not resolve an response object. I needed this because the cancelation of a customerSubscription is done by a DELETE method that have a response when the enddate is.
